### PR TITLE
Added the code for the satellite transceiver

### DIFF
--- a/satellite_transceiver_code/5-RF_Comms/5-RF_Comms.ino
+++ b/satellite_transceiver_code/5-RF_Comms/5-RF_Comms.ino
@@ -1,0 +1,291 @@
+
+/*
+ * Interorbital Systems' satellite kit demo program
+ * Demo-Comm
+ * Version 1.0, July 2020
+ * Author: Sylvain BURDOT (SGLB)
+ * 
+ * This is a demo program to get you started with you satellite. It is neither complete nor optimized to access the full functions of the kit. 
+ */
+
+//===============================================================================================
+/* This program demonstrate communication via radio signal.
+ * You will need a second radio to be able realise this example.
+ * 
+ * In this example, communication is only one way. The satellite is acting either as a receiver
+ * or a transmitter but ot both.
+ * 
+ * radio_config_Si4464.h is the configuration file for the transceiver. 
+ * In this file are located all the parameters of the different register of the transceiver that 
+ * are loaded on boot up. You will have to create your one for your own application. 
+ * 
+ * WARNING: when setting the output power of the transceiver up, do not go over 0x10.
+ * Otherwise the power received at the input of the power amplifier will exceed the maximum value 
+ * from the datasheet.
+ */
+//===============================================================================================
+
+
+#include "radio.h"
+
+#define RECEIVE false // If false, the transceiver will be set as transmitter. If true, will be set as receiver.
+
+
+/*
+ * This fonction is here for debugging purpose.
+ * Its only job is to display on the serial port how the tranceiver was configured.
+ */
+void printRadioConfig(){
+  Serial.println("\n========== RADIO CONFIGURATION DATA ARRAY ==========");
+  int byteNumber = 0;
+  int cmdNumber =1;
+
+  while(cfg[byteNumber] != 0x00){ // while the length of the command is different of zero (while there is any command left) 
+
+    
+    Serial.print("Command #" + String(cmdNumber,DEC) + " ");
+    int cmdLength = cfg[byteNumber]; //the first byte is the length of the command
+    Serial.print("\t(Length " + String(cmdLength,DEC) + " Bytes): \t");
+    
+    uint8_t cmd[cmdLength]; //creates a table to save the current command
+    byteNumber++;
+    
+    memcpy(cmd, &cfg[byteNumber], cmdLength);
+
+    for (int i=0; i<cmdLength; i++){
+      Serial.print(cmd[i],HEX);
+      Serial.print(" ");
+    }
+    byteNumber += cmdLength;
+    cmdNumber ++;
+    Serial.println();
+   
+  }
+  Serial.println("====================================================");
+}
+
+/*
+ * This fonction is here for debugging purpose.
+ * Its only job is to display on the info of the transceiver
+ */
+void printRadioInfo(){
+      //Reading radio part info
+   if (radioReady()==true){
+      uint8_t cmd[]={0x01};
+      uint8_t info[8];
+      radioCommand(cmd, sizeof(cmd), info, sizeof(info));
+      Serial.println("\n========= RADIO INFO =========");
+      Serial.println("Model\t\tSi" +String(info[1],HEX) + String(info[2],HEX));
+
+      Serial.println("Revision\t" + String(info[0],HEX));
+      Serial.println("PBuild\t\t" + String(info[3],HEX));
+      Serial.println("ROM ID\t\t" + String(info[7],HEX));
+      
+      Serial.println("ID \t\t" + String(info[4],HEX) + String(info[5],HEX));
+      Serial.println("Customer ID\t" + String(info[6],HEX));
+      Serial.println("==============================");
+    }
+  else Serial.println("Radio not ready");
+  float radioVoltage=0;
+  float radioTemp=0;
+  radioBatTemp(&radioVoltage, &radioTemp);
+  Serial.print(radioVoltage);
+  Serial.println( "Radio Voltage: \t\t" +String(radioVoltage) + "V");
+  Serial.println("Radio Temperature: \t" + String(radioTemp) + "°C");
+}
+
+
+
+//===============================================================================================
+
+void setup() {
+  
+  pinMode(49,OUTPUT);
+  Serial.begin(9600);
+  SPI.begin();
+  Serial.println("\nHELLO WORLD!  Initializing...\n");
+
+  // displays the configuration of the radio
+  printRadioConfig(); 
+
+  //Let's initialize the transceiver
+  int cfgResult = radioInit(); 
+  
+  //Now let's make sure the radio was initialized properly
+  if (cfgResult == 0){ 
+    uint8_t cmd[]= {REQUEST_DEVICE_STATE};
+    uint8_t ans[2];
+
+    //Let's check for the transceiver state
+    if (radioCommand(cmd, sizeof(cmd), ans, sizeof(ans))){
+      if ((ans[0] == 3) || (ans[0] ==4)){
+         Serial.println("Radio init \t\t\tDONE!");
+         Serial.println("Radio current channel: \t\t" + String(ans[1]));
+         printRadioInfo(); //displays the part info
+      }
+      else {
+        Serial.println("ERROR DURING CONFIG: Transceiver sate =" + String(ans[0],DEC));
+      }
+    }
+    
+  }
+  else{
+    Serial.println("ERROR DURING CONFIG: " + String(cfgResult, DEC));
+  }
+
+  Serial.println();
+
+  
+  uint8_t intStatus[]= {GET_INT_STATUS, 0xFB, 0x7F, 0x7F}; //This is the command for reading the interruption status without clearing them
+  uint8_t intStatusClear[]= {GET_INT_STATUS, 0x00, 0x00, 0x00}; //This command is the same as the previous one but will clear the interruption status
+  uint8_t interr[8];
+
+  //We will now read and print on the serial port the interruptions status
+  //This is use to make sure one more time that the transceiver was initialized correctly
+  Serial.print("Checking interrupt status: \t");
+  if (radioCommand(intStatus, sizeof(intStatus), interr, sizeof(interr))){
+    for (int i = 0; i< sizeof(interr); i++){
+      Serial.print(interr[i],HEX);
+      Serial.print("\t");  
+    }
+    Serial.println();
+  }
+
+  //Now let's check the chip status
+  //It is not strictly necessary but gets a bit more  info on the chip status that are not given by the interruption status
+  uint8_t cmd2[] = {GET_CHIP_STATUS};
+  uint8_t ans[4];
+  Serial.print("Checking chip status: \t\t");
+  if (radioCommand(cmd2, sizeof(cmd2), ans, sizeof(ans))){
+    for (int i = 0; i< sizeof(ans); i++){
+      Serial.print(ans[i],HEX);
+      Serial.print("\t");  
+    }
+    Serial.println();
+  }
+  Serial.println();
+
+
+
+  if (RECEIVE == false){
+    Serial.println("SET as a transmitter");
+  }
+
+  //This will set the transceiver into RX mode and command it to start listening on channel 0
+  else if (RECEIVE == true){
+    Serial.println("SET as a receiver");
+    digitalWrite(49,HIGH);
+    uint8_t channel= 0x00;
+    uint8_t RxCmd[] = {START_RX, channel, 0x00, 0x00, 0x00, 0x08, 0x08, 0x08};
+    if (radioCommand(RxCmd,sizeof(RxCmd))!= true){
+      Serial.println("FAIL to enter RX!");
+    }
+    
+  }
+  Serial.println("End of setup");
+
+  
+}
+
+
+
+
+void loop() {
+
+  //If the transceiver as been as a transmitter
+  if (RECEIVE == false){ 
+
+    //This block was added to test the ability to send data//
+    float radioVoltage=0;
+    float radioTemp=0;
+    radioBatTemp(&radioVoltage, &radioTemp);
+    String volt = String(radioVoltage);
+    Serial.print(volt);
+    //Serial.print(radioVoltage);
+    //Serial.println( "Radio Voltage: \t\t" +String(radioVoltage) + "V");
+    //Serial.println("Radio Temperature: \t" + String(radioTemp) + "°C");
+    //
+
+    
+    //The message that will be sent is "HELLO!!"
+    uint8_t FIFOCmd[] = {WRITE_TX_FIFO, volt[0], volt[1], volt[2], volt[3]}; 
+    //uint8_t FIFOCmd[] = {WRITE_TX_FIFO, 0x48, 0x45, 0x4C, 0x4C, 0x4F, 0x21, 0x21};
+
+    //It needs to be written to the FIFO buffer before being transmitted
+    RADIO_CTRL_PORT &= ~SS_radio; 
+    for( int i =0; i<sizeof(FIFOCmd); i++){
+      SPI.transfer(FIFOCmd[i]);
+    }
+    RADIO_CTRL_PORT |= SS_radio;
+
+    //Now the radio can be set in Tx mode and start transmitting what is in the FIFO buffer
+    uint8_t channel = 0x00;
+    uint8_t txCmd[] = {START_TX, channel, 0x00, 0x00, 0x00};
+    if (radioCommand(txCmd,sizeof(txCmd))){
+      Serial.println("Packet sent!");
+    }
+    else Serial.println("Sending FAILED!");
+
+    //You might want to clear the FIFO buffer after transmittion
+    uint8_t infoClear[] = {FIFO_INFO, 0x02};
+    uint8_t siz[2];
+    radioCommand(infoClear, sizeof(infoClear), siz, sizeof(siz));
+
+    //Blinking an LED is done purely for a debugging purpose
+    digitalWrite(49,HIGH);
+    delay(1000);
+    digitalWrite(49,LOW);
+    delay(1000);
+  }
+
+
+
+  //If transceiver as been set as a receiver
+  else if (RECEIVE == true){ // is set as receiver
+    
+  uint8_t PHStatus[]= {GET_PH_STATUS, 0x00};
+  uint8_t PHint[2];  
+
+    // First we check the interrupt status to see if any packet was received properly
+    if (radioCommand(PHStatus, sizeof(PHStatus), PHint, sizeof(PHint))){
+      if ((PHint[0] & 0x10)== 0x10){       
+
+        // If this is the case we will need to retrieve the received packet from the FIFO buffer
+        uint8_t info[] = {FIFO_INFO, 0x00};
+        uint8_t siz[2];
+        if (radioCommand(info, sizeof(info), siz, sizeof(siz))){
+          uint8_t Read[]= {READ_RX_FIFO};
+
+          //Let's create an array to store the received bytes
+          uint8_t rx[siz[0]];
+          
+          //Then initialize i
+          for (int i = 0; i< sizeof(rx); i++){ 
+            rx[i]=0xFF;
+          }
+
+          //The FIFO buffer can now be read
+          RADIO_CTRL_PORT &= ~SS_radio; // sets the chip select pin LOW
+          SPI.transfer(READ_RX_FIFO);
+          for (int i = 0; i< sizeof(rx); i++){ //initializing storage
+            rx[i]=SPI.transfer(0x00);
+          }
+          RADIO_CTRL_PORT |= SS_radio; //sets the chip select pin HIGH
+
+          //And the received bytes printed on the serial port
+          Serial.print("RECEIVED: \t");
+          for (int i = 0; i< sizeof(rx); i++){
+            Serial.write(rx[i]);
+            Serial.print("\t");  
+          }
+        }
+
+        //Once this is done, let's clear the FIFO buffer
+        uint8_t infoClear[] = {FIFO_INFO, 0x02};
+        if (radioCommand(infoClear, sizeof(infoClear), siz, sizeof(siz))){ //clears RX FIFO
+          Serial.println();
+        }
+      }
+    }
+  }
+}

--- a/satellite_transceiver_code/5-RF_Comms/radio.cpp
+++ b/satellite_transceiver_code/5-RF_Comms/radio.cpp
@@ -1,0 +1,195 @@
+#include "radio.h"
+
+
+
+
+/*
+ * This function configures the transceiver
+ */
+int radioConfig(){
+
+  int byteNumber = 0;
+  int cmdNumber =1;
+  
+  while(cfg[byteNumber] != 0x00){ // while the length of the command is different of zero (while there is any command left) 
+    
+    uint8_t cmdLength = cfg[byteNumber]; //the first byte is the length of the command
+    uint8_t cmd[cmdLength]; //creates a table to save the current command
+    byteNumber++;
+    
+    memcpy(cmd, &cfg[byteNumber], cmdLength); //copies the command into the array previously created
+   
+    if (radioCommand(cmd, cmdLength)){//sends command to the radio and checks if the result is true
+      if (cmdNumber ==1){
+        uint8_t cmd[]= {GET_INT_STATUS, 0x00, 0x00, 0x00}; //Cmd: Clear all interrupt flag
+        radioCommand(cmd, sizeof(cmd));
+      }
+      byteNumber += cmdLength; //moves to the next command
+      cmdNumber++; 
+    }
+    else return cmdNumber; // Returns which configuration command was not exacuted properly
+  }
+  uint8_t answer[1];
+  uint8_t command[]= {SET_PROPERTY, 0x00, 0x01, 0x02, 0x08}; // Sets the low battery threshold to 1.9V
+  if (radioCommand(command, sizeof(command), answer, sizeof(answer))){
+    return 0; // Radio was configured properly
+  }
+
+}
+
+
+/*
+ * This function execute the initialzing sequence of the tranceiver
+
+ */
+int radioInit(){
+  //sets SS_Radio, SDN, Bypass and EN_PA as output
+  RADIO_CTRL_PORT_DIR |= (SS_radio | SDN | Bypass | EN_PA); 
+  
+  // sets nIRQ as input
+  RADIO_INT_PORT_DIR &= ~nIRQ; 
+  
+  //sets SS_Radio, SDN and bypass HIGH
+  RADIO_CTRL_PORT |=(SS_radio | SDN); 
+
+  //sets EN_PA HIGH
+  RADIO_CTRL_PORT |= EN_PA;
+
+  //sets Bypass LOW
+  RADIO_CTRL_PORT &= ~Bypass;
+
+  //forces the transceiver to reset
+  radioShutdown();
+  radioPowerUp();
+
+  //Configures the transceiver
+  int cfgResult = radioConfig();
+
+  
+  if (cfgResult ==0){ // if the configuration was successful
+    uint8_t cmd[]= {GET_INT_STATUS, 0xFB, 0x7F, 0x7F}; //Cmd: Clear all interrupt flag
+    if (radioCommand(cmd, sizeof(cmd))){
+      return 0; // At this time the radio should be fully configured and READY
+    }
+  }
+  else return cfgResult;
+   
+}
+
+
+
+/*
+ * This function will check if the transceiver is ready to accept a new command
+ */
+bool radioReady(){
+  bool stat = false; //If stat = true then the transceiver is ready to receive a new command.
+  int count =0;
+
+  //We will give it a thousand try before given up, to let it time to finish what is is doing 
+  while ((false!=true) && (count < 1000)){
+      RADIO_CTRL_PORT &= ~SS_radio;
+      SPI.transfer(READ_CMD_BUFF);
+      if (SPI.transfer(0) == CTS){
+        stat = true;
+      }
+      count++;
+      RADIO_CTRL_PORT |= SS_radio;
+    }
+  return stat;
+}
+
+
+
+
+
+/*
+ * This function forces the transceiver to shutdown
+ */
+
+void radioShutdown(){
+  RADIO_CTRL_PORT |= SDN; //turns SDN pin HIGH 
+  delay(10);
+   
+}
+
+/*
+ * This function forces the shutdown pin back to LOW, turning on the transceiver
+ */
+uint8_t radioPowerUp(){
+  //Power On Reset
+  RADIO_CTRL_PORT &= ~SDN; //sets SDN pin LOW
+  delay(20); //the si4464 needs a maximum of 6ms before being able to do anything after powering up
+}
+
+
+
+/*
+ * This function will send a command to the transceiver and recover potential answers
+ * 
+ * const char* write_buf: address of the array containing the command bytes
+ * char write_len: Number of bytes in the command
+ * char* read_buf: (Optional) address of the array that will store the answer
+ * char* read_len: (Optional) length of the answer
+ */
+bool radioCommand(const char* write_buf, char write_len, char* read_buf, char read_len)
+{
+    bool done = false; //if command is executed then done= true
+    int count=0;
+
+      
+    //Let send the command bytes to the transceiver over SPI
+    RADIO_CTRL_PORT &= ~SS_radio; // sets the chip select pin LOW
+    if (write_buf && write_len){ 
+      while (write_len--){
+        SPI.transfer(*write_buf++);
+      }
+    }
+    RADIO_CTRL_PORT |= SS_radio; //sets the chip select pin HIGH
+
+
+    //Now let's make sure the command was executed and read the answer if there is any
+    while ((done!=true) && (count < 1500)){ // Up to 1500 retry to check if the radio is ready 
+      
+      RADIO_CTRL_PORT &= ~SS_radio;
+      SPI.transfer(READ_CMD_BUFF);
+      //Let's check if the radio is ready
+      if (SPI.transfer(0) == CTS){
+        //and receive the answer if there is any
+        if (read_buf && read_len){ 
+          while (read_len--){
+            *read_buf++ = SPI.transfer(0x00); 
+            
+          }
+        }
+        done = true;
+      }
+      count++;
+      RADIO_CTRL_PORT |= SS_radio;
+    }
+    
+    return done; // False if too many attempts at CTS
+}
+
+
+/*
+ * This function reads the ADC internal to the transceiver to access the voltage and the temperature of the transceiver
+ * 
+ * float *battery: address of the variable to store the voltage of the transceiver
+ * float *degree: address of the variable to store the temperature of the transceiever
+ */
+void radioBatTemp(float *battery, float *degree){
+  
+   if (radioReady()==true){ //Checking that the transceiver is not busy
+      uint8_t cmd[]={GET_ADC_READING, 0x18}; // reads only temperature and battery voltage
+      uint8_t info[6];
+      radioCommand(cmd, sizeof(cmd), info, sizeof(info));
+      
+      // The raw values of voltage is store on bytes 2 & 3; temperature on bytes 4 & 5
+      uint16_t batByte = (info[2]<<8) | info[3];
+      uint16_t tempByte = (info[4]<<8) | info[5];
+
+      //Now let's convert that into actual volts and degrees
+      *battery = (3*float(batByte))/float(1280);
+      *degree = (float(tempByte)*(899/float(4096)))-293;
+   }
+}

--- a/satellite_transceiver_code/5-RF_Comms/radio.h
+++ b/satellite_transceiver_code/5-RF_Comms/radio.h
@@ -1,0 +1,78 @@
+//#include <avr/io.h>
+
+#include "radio_config_Si4464.h"
+
+#include <SPI.h>
+//the list of following commans comes from the Silabs AN633
+
+//Boot command
+#define POWER_UP                   0x02
+//common commands
+#define NOP                        0x00
+#define PART_INFO                  0x01
+#define FUNC_INFO                  0x10
+#define SET_PROPERTY               0x11
+#define GET_PROPERTY               0x12
+#define GPIO_PIN_CFG               0x13
+#define FIFO_INFO                  0x15
+#define GET_INT_STATUS             0x20
+#define REQUEST_DEVICE_STATE       0x33
+#define CHANGE_STATE               0x34
+#define READ_CMD_BUFF              0x44
+#define FRR_A_READ                 0x50
+#define FRR_B_READ                 0x51
+#define FRR_C_READ                 0x53
+#define FRR_D_READ                 0x57
+//Cal commands
+#define IRCAL                      0x17
+#define IRCAL_MANUAL               0x19
+//TX commands
+#define START_TX                   0x31
+#define TX_HOP                     0x31
+#define WRITE_TX_FIFO              0x66
+//RX commands
+#define PACKET_INFO                0x16
+#define GET_MODEM_STATUS           0x22
+#define START_RX                   0x32
+#define RX_HOP                     0x36
+#define READ_RX_FIFO               0x77
+//Advanced commands
+#define GET_ADC_READING            0x14
+#define GET_PH_STATUS              0x21
+#define GET_CHIP_STATUS            0x23
+
+
+#define CTS 0xFF
+
+
+#define RADIO_CTRL_PORT       PORTH
+#define RADIO_CTRL_PORT_DIR   DDRH
+//#define RADIO_CTRL_PORT       PORTL
+//#define RADIO_CTRL_PORT_DIR   DDRL
+
+#define RADIO_INT_PORT        PORTE
+#define RADIO_INT_PORT_DIR    DDRE
+
+#define SS_radio    0b10000000
+#define SDN         0b01000000
+#define Bypass      0b00100000
+#define EN_PA       0b00010000
+#define nIRQ        0b01000000
+
+/*#define SS_radio    0b00000010
+
+#define SDN         0b00001000
+#define EN_PA       0b00010000
+#define Bypass      0b00100000*/
+
+
+static const uint8_t cfg[] = RADIO_CONFIGURATION_DATA_ARRAY;
+
+
+
+int radioInit();
+void radioShutdown();
+uint8_t radioPowerUp();
+bool radioCommand( const char* write_buf, char write_len , char* read_buf=0, char read_len=0);
+bool radioReady();
+void radioBatTemp(float *battery, float *degree);

--- a/satellite_transceiver_code/5-RF_Comms/radio_config_Si4464.h
+++ b/satellite_transceiver_code/5-RF_Comms/radio_config_Si4464.h
@@ -1,0 +1,641 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si4464 Rev.: B1                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 2    Rsymb(sps): 10000    Fdev(Hz): 20000    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 3    
+// RF Freq.(MHz): 434    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 4 (BW =  82.64 kHz);  NB-filter 4 (BW = 82.64 kHz)
+// 
+// Modulation index: 4
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+//#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD             {0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x20, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x01
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x80, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x02, 0x00, 0x07, 0x01, 0x86, 0xA0, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x05
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x76
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0x80, 0x00, 0x20, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x01, 0x77, 0x01, 0x5D, 0x86, 0x00, 0xAF, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x36, 0x80, 0x1D, 0x10, 0x04, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x52, 0x52, 0x00, 0x02, 0xFF, 0xFF, 0x00, 0x2A
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x01, 0x20, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x0A
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xA2, 0x81, 0x26, 0xAF, 0x3F, 0xEE, 0xC8, 0xC7, 0xDB, 0xF2, 0x02, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x07, 0x03, 0x15, 0xFC, 0x0F, 0x00, 0xA2, 0x81, 0x26, 0xAF, 0x3F, 0xEE
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC8, 0xC7, 0xDB, 0xF2, 0x02, 0x08, 0x07, 0x03, 0x15, 0xFC, 0x0F, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x01, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0E, 0xEE, 0xEE, 0x44, 0x44, 0x20, 0xFE
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */


### PR DESCRIPTION
This is the example code given to us by Interorbital Systems for transmitting and receiving radio packets using the si4464. This code has the pinout for the satellite and is currently set to transmit the battery voltage. Using this code as well as #3 for the ground station, we successfully sent and received messages.